### PR TITLE
Fix missing Oracle driver in prod profile

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -34,6 +34,7 @@ spring:
     url: jdbc:oracle:thin:@tssjdb_medium?TNS_ADMIN=${DB_WALLET_PATH}
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
+    driver-class-name: oracle.jdbc.OracleDriver
 
   jpa:
     hibernate:


### PR DESCRIPTION
## Summary
- specify `oracle.jdbc.OracleDriver` for the production datasource

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_686a3a1ea644832e9457a35d7dff1a58